### PR TITLE
Replaced uri module with shell curl command. 

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,15 +21,15 @@
     src: 'benchmarks/{{ test_name }}.yaml.j2'
     dest: '/tmp/{{ test_name }}.yaml'
     force: yes
-- name: Upload benchmark template
-  uri:
-    src: '/tmp/{{ test_name }}.yaml'
-    remote_src: yes
-    method: POST
-    headers:
-      Content-Type: "text/vnd.yaml; charset=UTF-8"
-    url: "http://{{ hyperfoil_controller_host }}:{{ hyperfoil_controller_port }}/benchmark"
-    status_code: "204"
+- name: Define benchmark upload file variable
+  when: upload_parts is undefined
+  set_fact: upload_parts: '-F "benchmark=@/tmp/{{ test_name }}.yaml"'
+- name: Upload benchmark template 
+  shell: 'curl -f -X POST \
+    {{ upload_parts | join(" ") }} \
+    http://{{ hyperfoil_controller_host }}:{{ hyperfoil_controller_port }}/benchmark'
+  register: curl_cmd
+  failed_when: curl_cmd.rc > 1
 - name: Start benchmark
   uri:
     url: "http://{{ hyperfoil_controller_host }}:{{ hyperfoil_controller_port }}/benchmark/{{ test_name }}/start"


### PR DESCRIPTION
 This PR solves the issue #3 .
 The uri module has been swapped with curl.

 To keep the behaviour the same a failure condition on return code will halt the playbook if the upload fails.