### PR TITLE
Delegate needs to resolve the variable otherwise can't connect

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
   - name: Gather facts about controller
     when: hostvars[groups[hyperfoil_controller_group][0]]['ansible_hostname'] is undefined
     setup: {}
-    delegate_to: groups[hyperfoil_controller_group][0]
+    delegate_to: "{{ groups[hyperfoil_controller_group][0] }}"
     delegate_facts: true
   - name: Set hyperfoil_controller_host
     set_fact:


### PR DESCRIPTION
If `hyperfoil_controller_host` is undefined, which can happen when running hyperfoil_test without hyperfoil_setup in the same playbook, it will fail to retrieve the facts as the host will be resolved as `groups[hyperfoil_controller_group][0]` instead of retrieving the value.